### PR TITLE
Fix Issue 3 - Fill throwing index out of range

### DIFF
--- a/IPv4Net.go
+++ b/IPv4Net.go
@@ -116,8 +116,6 @@ func (net *IPv4Net) Fill(list IPv4NetList) IPv4NetList {
 				subs = append(subs, e)
 			}
 		}
-		// discard subnets of subnets & sort
-		subs = subs.discardSubnets().Sort()
 	} else {
 		return subs
 	}
@@ -125,6 +123,9 @@ func (net *IPv4Net) Fill(list IPv4NetList) IPv4NetList {
 	// fill
 	var filled IPv4NetList
 	if len(subs) > 0 {
+		// discard subnets of subnets & sort
+		subs = subs.discardSubnets().Sort()
+
 		// bottom fill if base address is missing
 		base := net.base.addr
 		if subs[0].base.addr != base {
@@ -241,7 +242,7 @@ func (net *IPv4Net) Rel(other *IPv4Net) (bool, int) {
 		return false, 0
 	}
 
-	// when networks are equal then we can look exlusively at the netmask
+	// when networks are equal then we can look exclusively at the netmask
 	if net.base.addr == other.base.addr {
 		return true, net.m32.Cmp(other.m32)
 	}

--- a/IPv4Net_test.go
+++ b/IPv4Net_test.go
@@ -33,14 +33,6 @@ func ExampleIPv4Net_Fill() {
 	// Output: [10.0.0.0/26 10.0.0.64/26 10.0.0.128/25]
 }
 
-func ExampleIPv4Net_Fill_Same_Net() {
-	net, _ := ParseIPv4Net("10.0.0.0/24")
-	subs, _ := NewIPv4NetList([]string{"10.0.0.0/24"})
-	subs = net.Fill(subs) // fills in the missing subnets
-	fmt.Println(subs)
-	// Output: []
-}
-
 func ExampleIPv4Net_Next() {
 	net, _ := ParseIPv4Net("10.0.0.4/30")
 	next := net.Next()
@@ -236,6 +228,11 @@ func Test_IPv4Net_Fill(t *testing.T) {
 			"1.0.0.0/25",
 			[]string{"1.0.0.0/30", "1.0.0.64/26"},
 			[]string{"1.0.0.0/30", "1.0.0.4/30", "1.0.0.8/29", "1.0.0.16/28", "1.0.0.32/27", "1.0.0.64/26"},
+		},
+		{
+			"10.0.0.0/24",  // Test clean-up with empty return
+			[]string{"10.0.0.0/24"},
+			[]string{},
 		},
 	}
 

--- a/IPv4Net_test.go
+++ b/IPv4Net_test.go
@@ -1,7 +1,9 @@
 package netaddr
 
-import "testing"
-import "fmt"
+import (
+	"fmt"
+	"testing"
+)
 
 func ExampleParseIPv4Net() {
 	net, _ := ParseIPv4Net("10.0.0.0/24")
@@ -25,10 +27,18 @@ func ExampleIPv4Net_Extended() {
 
 func ExampleIPv4Net_Fill() {
 	net, _ := ParseIPv4Net("10.0.0.0/24")
-	subs,_ := NewIPv4NetList([]string{"10.0.0.0/26"})
-	subs = net.Fill(subs)           // fills in the missing subnets
+	subs, _ := NewIPv4NetList([]string{"10.0.0.0/26"})
+	subs = net.Fill(subs) // fills in the missing subnets
 	fmt.Println(subs)
 	// Output: [10.0.0.0/26 10.0.0.64/26 10.0.0.128/25]
+}
+
+func ExampleIPv4Net_Fill_Same_Net() {
+	net, _ := ParseIPv4Net("10.0.0.0/24")
+	subs, _ := NewIPv4NetList([]string{"10.0.0.0/24"})
+	subs = net.Fill(subs) // fills in the missing subnets
+	fmt.Println(subs)
+	// Output: []
 }
 
 func ExampleIPv4Net_Next() {
@@ -55,7 +65,7 @@ func ExampleIPv4Net_Nth() {
 
 func ExampleIPv4Net_NthSubnet() {
 	net, _ := ParseIPv4Net("10.0.0.0/24")
-	fmt.Println(net.NthSubnet(30,2)) // the 3rd /30 subnet
+	fmt.Println(net.NthSubnet(30, 2)) // the 3rd /30 subnet
 	// Output: 10.0.0.8/30
 }
 
@@ -188,8 +198,8 @@ func Test_IPv4Net_Cmp(t *testing.T) {
 
 func Test_IPv4Net_Contains(t *testing.T) {
 	cases := []struct {
-		net    string
-		ip     string
+		net      string
+		ip       string
 		contains bool
 	}{
 		{"1.0.0.8/29", "1.0.0.15", true},
@@ -198,10 +208,10 @@ func Test_IPv4Net_Contains(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		net,_ := ParseIPv4Net(c.net)
-		ip,_ := ParseIPv4(c.ip)
+		net, _ := ParseIPv4Net(c.net)
+		ip, _ := ParseIPv4(c.ip)
 		if c.contains != net.Contains(ip) {
-			t.Errorf("%s.Contains(%s) Expect: %v  Result: %v", c.net,c.ip,c.contains,!c.contains)
+			t.Errorf("%s.Contains(%s) Expect: %v  Result: %v", c.net, c.ip, c.contains, !c.contains)
 		}
 	}
 }
@@ -363,7 +373,7 @@ func Test_IPv4Net_NthSubnet(t *testing.T) {
 
 	for _, c := range cases {
 		net, _ := ParseIPv4Net(c.given)
-		nth := net.NthSubnet(c.prefix,c.nth)
+		nth := net.NthSubnet(c.prefix, c.nth)
 		if nth == nil {
 			if c.expect != "" {
 				t.Errorf("%s.NthSubnet(%d,%d) Expect: %s  Result: nil", c.given, c.prefix, c.nth, c.expect)

--- a/IPv6Net.go
+++ b/IPv6Net.go
@@ -102,8 +102,7 @@ func (net *IPv6Net) Fill(list IPv6NetList) IPv6NetList {
 				subs = append(subs, e)
 			}
 		}
-		// discard subnets of subnets & sort
-		subs = subs.discardSubnets().Sort()
+
 	} else {
 		return subs
 	}
@@ -111,6 +110,9 @@ func (net *IPv6Net) Fill(list IPv6NetList) IPv6NetList {
 	// fill
 	var filled IPv6NetList
 	if len(subs) > 0 {
+		// discard subnets of subnets & sort
+		subs = subs.discardSubnets().Sort()
+
 		// bottom fill if base address is missing
 		cmp, _ := net.base.Cmp(subs[0].base)
 		if cmp != 0 {

--- a/IPv6Net_test.go
+++ b/IPv6Net_test.go
@@ -58,8 +58,8 @@ func Test_IPv6Net_Cmp(t *testing.T) {
 
 func Test_IPv6Net_Contains(t *testing.T) {
 	cases := []struct {
-		net    string
-		ip     string
+		net      string
+		ip       string
 		contains bool
 	}{
 		{"1:8::/29", "1:f::", true},
@@ -68,10 +68,10 @@ func Test_IPv6Net_Contains(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		net,_ := ParseIPv6Net(c.net)
-		ip,_ := ParseIPv6(c.ip)
+		net, _ := ParseIPv6Net(c.net)
+		ip, _ := ParseIPv6(c.ip)
 		if c.contains != net.Contains(ip) {
-			t.Errorf("%s.Contains(%s) Expect: %v  Result: %v", c.net,c.ip,c.contains,!c.contains)
+			t.Errorf("%s.Contains(%s) Expect: %v  Result: %v", c.net, c.ip, c.contains, !c.contains)
 		}
 	}
 }
@@ -91,6 +91,11 @@ func Test_IPv6Net_Fill(t *testing.T) {
 			"ff00::/121",
 			[]string{"ff00::/126", "ff00::/120"},
 			[]string{"ff00::/126", "ff00::4/126", "ff00::8/125", "ff00::10/124", "ff00::20/123", "ff00::40/122"},
+		},
+		{
+			"ff00::/8",
+			[]string{"ff00::/8"},
+			[]string{},
 		},
 	}
 
@@ -229,7 +234,7 @@ func Test_IPv6Net_NthSubnet(t *testing.T) {
 
 	for _, c := range cases {
 		net, _ := ParseIPv6Net(c.given)
-		nth := net.NthSubnet(c.prefix,c.nth)
+		nth := net.NthSubnet(c.prefix, c.nth)
 		if nth == nil {
 			if c.expect != "" {
 				t.Errorf("%s.NthSubnet(%d,%d) Expect: %s  Result: nil", c.given, c.prefix, c.nth, c.expect)

--- a/IPv6Net_test.go
+++ b/IPv6Net_test.go
@@ -93,7 +93,7 @@ func Test_IPv6Net_Fill(t *testing.T) {
 			[]string{"ff00::/126", "ff00::4/126", "ff00::8/125", "ff00::10/124", "ff00::20/123", "ff00::40/122"},
 		},
 		{
-			"ff00::/8",
+			"ff00::/8", // Test clean-up with empty return
 			[]string{"ff00::/8"},
 			[]string{},
 		},


### PR DESCRIPTION
By moving `subs.discardSubnets().Sort()` inside `len(subs) > 0` conditional, the below stacktrace was fixed which relates to issue #3.

```bash
--- FAIL: ExampleIPv4Net_Fill_Same_Net (0.00s)
coverage: 8.6% of statements
panic: runtime error: index out of range [-1] [recovered]
	panic: runtime error: index out of range [-1]

goroutine 1 [running]:
testing.(*InternalExample).processRunResult(0xc0000b1d20, 0x0, 0x0, 0x12a7c, 0x1015400, 0x115adc0, 0xc0000f8000, 0x175ffff)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/example.go:91 +0x69b
testing.runExample.func2(0xc018e931645b9e00, 0xb5bbf, 0x1260de0, 0xc0000a6038, 0xc0000a6008, 0xc0000b8180, 0xc0000b1d20, 0xc0000b1c7e, 0xc0000b1d50)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/run_example.go:59 +0x11c
panic(0x115adc0, 0xc0000f8000)
	/usr/local/Cellar/go/1.16.3/libexec/src/runtime/panic.go:965 +0x1b9
github.com/dspinhirne/netaddr-go.IPv4NetList.discardSubnets(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/comagnaw/repos/src/github.com/dspinhirne/netaddr-go/IPv4NetList.go:64 +0x3ff
github.com/dspinhirne/netaddr-go.(*IPv4Net).Fill(0xc0000aa730, 0xc0000a6040, 0x1, 0x1, 0x1, 0x1, 0x0)
	/Users/comagnaw/repos/src/github.com/dspinhirne/netaddr-go/IPv4Net.go:119 +0x1d3
github.com/dspinhirne/netaddr-go.ExampleIPv4Net_Fill_Same_Net()
	/Users/comagnaw/repos/src/github.com/dspinhirne/netaddr-go/IPv4Net_test.go:39 +0xb1
testing.runExample(0x11702f4, 0x1c, 0x11764f0, 0x116a1c5, 0x3, 0x0, 0x0)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/run_example.go:63 +0x222
testing.runExamples(0xc0000b1e98, 0x125dec0, 0x20, 0x20, 0xc018e938e4587180)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/example.go:44 +0x17a
testing.(*M).Run(0xc0000e6000, 0x0)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1418 +0x273
main.main()
	_testmain.go:307 +0x1c5
FAIL	github.com/dspinhirne/netaddr-go	0.696s
FAIL
```

Updates were made to both IPv4Net and IPv6Net Fill() methods and tests added to confirm FIll() only returns subnets of net.

In the case where the only subnet passed in the list is the same as the net, the FIll method will return an empty list, which holds true to description of Fill() method.


```bash
go test -v ./...
=== RUN   TestParseEUI48
--- PASS: TestParseEUI48 (0.00s)
=== RUN   TestEUI48_Strings
--- PASS: TestEUI48_Strings (0.00s)
=== RUN   TestEUI48_ToEUI64
--- PASS: TestEUI48_ToEUI64 (0.00s)
=== RUN   TestParseEUI64
--- PASS: TestParseEUI64 (0.00s)
=== RUN   TestEUI64_Strings
--- PASS: TestEUI64_Strings (0.00s)
=== RUN   TestEUI64_ToIPv6
--- PASS: TestEUI64_ToIPv6 (0.00s)
=== RUN   Test_NewIPv4List
--- PASS: Test_NewIPv4List (0.00s)
=== RUN   Test_NewIPv4NetList
--- PASS: Test_NewIPv4NetList (0.00s)
=== RUN   Test_IPv4NetList_Summ
--- PASS: Test_IPv4NetList_Summ (0.00s)
=== RUN   Test_ParseIPv4Net
--- PASS: Test_ParseIPv4Net (0.00s)
=== RUN   Test_NewIPv4Net
--- PASS: Test_NewIPv4Net (0.00s)
=== RUN   Test_IPv4Net_Cmp
--- PASS: Test_IPv4Net_Cmp (0.00s)
=== RUN   Test_IPv4Net_Contains
--- PASS: Test_IPv4Net_Contains (0.00s)
=== RUN   Test_IPv4Net_Fill
--- PASS: Test_IPv4Net_Fill (0.00s)
=== RUN   Test_IPv4Net_Len
--- PASS: Test_IPv4Net_Len (0.00s)
=== RUN   Test_IPv4Net_Next
--- PASS: Test_IPv4Net_Next (0.00s)
=== RUN   Test_IPv4Net_NextSib
--- PASS: Test_IPv4Net_NextSib (0.00s)
=== RUN   Test_IPv4Net_Nth
--- PASS: Test_IPv4Net_Nth (0.00s)
=== RUN   Test_IPv4Net_NthSubnet
--- PASS: Test_IPv4Net_NthSubnet (0.00s)
=== RUN   Test_IPv4Net_Prev
--- PASS: Test_IPv4Net_Prev (0.00s)
=== RUN   Test_IPv4Net_PrevSib
--- PASS: Test_IPv4Net_PrevSib (0.00s)
=== RUN   Test_IPv4Net_Rel
--- PASS: Test_IPv4Net_Rel (0.00s)
=== RUN   Test_IPv4Net_Resize
--- PASS: Test_IPv4Net_Resize (0.00s)
=== RUN   Test_IPv4Net_String
--- PASS: Test_IPv4Net_String (0.00s)
=== RUN   Test_IPv4Net_SubnetCount
--- PASS: Test_IPv4Net_SubnetCount (0.00s)
=== RUN   Test_IPv4Net_Summ
--- PASS: Test_IPv4Net_Summ (0.00s)
=== RUN   Test_ParseIPv4
--- PASS: Test_ParseIPv4 (0.00s)
=== RUN   Test_IPv4_Cmp
--- PASS: Test_IPv4_Cmp (0.00s)
=== RUN   Test_MulticastMac
--- PASS: Test_MulticastMac (0.00s)
=== RUN   Test_IPv4_String
--- PASS: Test_IPv4_String (0.00s)
=== RUN   Test_Ipv4_ToNet
--- PASS: Test_Ipv4_ToNet (0.00s)
=== RUN   Test_NewIPv6List
--- PASS: Test_NewIPv6List (0.00s)
=== RUN   Test_NewIPv6NetList
--- PASS: Test_NewIPv6NetList (0.00s)
=== RUN   Test_IPv6NetList_Summ
--- PASS: Test_IPv6NetList_Summ (0.00s)
=== RUN   Test_ParseIPv6Net
--- PASS: Test_ParseIPv6Net (0.00s)
=== RUN   Test_IPv6Net_Cmp
--- PASS: Test_IPv6Net_Cmp (0.00s)
=== RUN   Test_IPv6Net_Contains
--- PASS: Test_IPv6Net_Contains (0.00s)
=== RUN   Test_IPv6Net_Fill
--- PASS: Test_IPv6Net_Fill (0.00s)
=== RUN   Test_IPv6Net_Len
--- PASS: Test_IPv6Net_Len (0.00s)
=== RUN   Test_IPv6Net_Next
--- PASS: Test_IPv6Net_Next (0.00s)
=== RUN   Test_IPv6Net_NextSib
--- PASS: Test_IPv6Net_NextSib (0.00s)
=== RUN   Test_IPv6Net_Nth
--- PASS: Test_IPv6Net_Nth (0.00s)
=== RUN   Test_IPv6Net_NthSubnet
--- PASS: Test_IPv6Net_NthSubnet (0.00s)
=== RUN   Test_IPv6Net_Prev
--- PASS: Test_IPv6Net_Prev (0.00s)
=== RUN   Test_IPv6Net_PrevSib
--- PASS: Test_IPv6Net_PrevSib (0.00s)
=== RUN   Test_IPv6Net_Rel
--- PASS: Test_IPv6Net_Rel (0.00s)
=== RUN   Test_IPv6Net_Resize
--- PASS: Test_IPv6Net_Resize (0.00s)
=== RUN   Test_IPv6Net_SubnetCount
--- PASS: Test_IPv6Net_SubnetCount (0.00s)
=== RUN   Test_IPv6Net_Summ
--- PASS: Test_IPv6Net_Summ (0.00s)
=== RUN   Test_ParseIPv6
--- PASS: Test_ParseIPv6 (0.00s)
=== RUN   Test_IPv6_Cmp
--- PASS: Test_IPv6_Cmp (0.00s)
=== RUN   Test_IPv6_IPv4
--- PASS: Test_IPv6_IPv4 (0.00s)
=== RUN   Test_IPv6_Long
--- PASS: Test_IPv6_Long (0.00s)
=== RUN   Test_IPv6_String
--- PASS: Test_IPv6_String (0.00s)
=== RUN   Test_Ipv6_ToNet
--- PASS: Test_Ipv6_ToNet (0.00s)
=== RUN   Test_ParseMask128
--- PASS: Test_ParseMask128 (0.00s)
=== RUN   Test_NewMask128
--- PASS: Test_NewMask128 (0.00s)
=== RUN   Test_Mask128_String
--- PASS: Test_Mask128_String (0.00s)
=== RUN   Test_Mask128_Cmp
--- PASS: Test_Mask128_Cmp (0.00s)
=== RUN   Test_ParseMask32
--- PASS: Test_ParseMask32 (0.00s)
=== RUN   Test_NewMask32
--- PASS: Test_NewMask32 (0.00s)
=== RUN   Test_Mask32_Extended
--- PASS: Test_Mask32_Extended (0.00s)
=== RUN   Test_Mask32_Cmp
--- PASS: Test_Mask32_Cmp (0.00s)
=== RUN   Test_Mask32_String
--- PASS: Test_Mask32_String (0.00s)
=== RUN   Test_IPv4PrefixLen
--- PASS: Test_IPv4PrefixLen (0.00s)
=== RUN   ExampleEUI64_ToIPv6
--- PASS: ExampleEUI64_ToIPv6 (0.00s)
=== RUN   ExampleIPv4List_Sort
--- PASS: ExampleIPv4List_Sort (0.00s)
=== RUN   ExampleNewIPv4NetList
--- PASS: ExampleNewIPv4NetList (0.00s)
=== RUN   ExampleIPv4NetList_Sort
--- PASS: ExampleIPv4NetList_Sort (0.00s)
=== RUN   ExampleIPv4NetList_Summ
--- PASS: ExampleIPv4NetList_Summ (0.00s)
=== RUN   ExampleParseIPv4Net
--- PASS: ExampleParseIPv4Net (0.00s)
=== RUN   ExampleNewIPv4Net
--- PASS: ExampleNewIPv4Net (0.00s)
=== RUN   ExampleIPv4Net_Extended
--- PASS: ExampleIPv4Net_Extended (0.00s)
=== RUN   ExampleIPv4Net_Fill
--- PASS: ExampleIPv4Net_Fill (0.00s)
=== RUN   ExampleIPv4Net_Fill_Same_Net
--- PASS: ExampleIPv4Net_Fill_Same_Net (0.00s)
=== RUN   ExampleIPv4Net_Next
--- PASS: ExampleIPv4Net_Next (0.00s)
=== RUN   ExampleIPv4Net_NextSib
--- PASS: ExampleIPv4Net_NextSib (0.00s)
=== RUN   ExampleIPv4Net_Nth
--- PASS: ExampleIPv4Net_Nth (0.00s)
=== RUN   ExampleIPv4Net_NthSubnet
--- PASS: ExampleIPv4Net_NthSubnet (0.00s)
=== RUN   ExampleIPv4Net_Prev
--- PASS: ExampleIPv4Net_Prev (0.00s)
=== RUN   ExampleIPv4Net_PrevSib
--- PASS: ExampleIPv4Net_PrevSib (0.00s)
=== RUN   ExampleIPv4Net_Resize
--- PASS: ExampleIPv4Net_Resize (0.00s)
=== RUN   ExampleIPv4Net_Summ
--- PASS: ExampleIPv4Net_Summ (0.00s)
=== RUN   ExampleParseIPv4
--- PASS: ExampleParseIPv4 (0.00s)
=== RUN   ExampleNewIPv4
--- PASS: ExampleNewIPv4 (0.00s)
=== RUN   ExampleIPv6List_Sort
--- PASS: ExampleIPv6List_Sort (0.00s)
=== RUN   ExampleNewIPv6NetList
--- PASS: ExampleNewIPv6NetList (0.00s)
=== RUN   ExampleIPv6NetList_Sort
--- PASS: ExampleIPv6NetList_Sort (0.00s)
=== RUN   ExampleIPv6NetList_Summ
--- PASS: ExampleIPv6NetList_Summ (0.00s)
=== RUN   ExampleParseMask32
--- PASS: ExampleParseMask32 (0.00s)
=== RUN   ExampleNewMask32
--- PASS: ExampleNewMask32 (0.00s)
=== RUN   ExampleMask32_Extended
--- PASS: ExampleMask32_Extended (0.00s)
=== RUN   ExampleIPv4PrefixLen
--- PASS: ExampleIPv4PrefixLen (0.00s)
=== RUN   ExampleParseIP
--- PASS: ExampleParseIP (0.00s)
=== RUN   ExampleParseIP_6
--- PASS: ExampleParseIP_6 (0.00s)
=== RUN   ExampleParseIPNet
--- PASS: ExampleParseIPNet (0.00s)
=== RUN   ExampleParseIPNet_6
--- PASS: ExampleParseIPNet_6 (0.00s)
PASS
ok      github.com/dspinhirne/netaddr-go        (cached)
```